### PR TITLE
Added missing PCI device IDs

### DIFF
--- a/nnt_device_list.h
+++ b/nnt_device_list.h
@@ -17,22 +17,38 @@ static struct pci_device_id pciconf_devices[] = {
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 4129) },  /* ConnectX-7     */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 41682) }, /* BlueField      */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 41686) }, /* BlueField 2    */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 41692) }, /* BlueField 3    */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 41694) }, /* BlueField 4    */
         { 0, }
 };
 
 
 static struct pci_device_id livefish_pci_devices[] = {
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x01f6) }, /* ConnectX-3 Flash Recovery     */
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x01f8) }, /* ConnectX-3 Pro Flash Recovery */
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x01ff) }, /* ConnectX-IB Flash Recovery    */
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0209) }, /* ConnectX-4 Flash Recovery     */
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x020b) }, /* ConnectX-4Lx Flash Recovery   */
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x020d) }, /* ConnectX-5 Flash Recovery     */
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x020f) }, /* ConnectX-6 Flash Recovery     */
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0212) }, /* ConnectX-6DX Flash Recovery   */
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0216) }, /* ConnectX-6LX Flash Recovery   */
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0218) }, /* ConnectX-7 Flash Recovery     */
-        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0211) }, /* BlueField Flash Recovery      */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x01f6) }, /* ConnectX-3 Flash Recovery             */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x01f8) }, /* ConnectX-3 Pro Flash Recovery         */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x01ff) }, /* ConnectX-IB Flash Recovery            */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0209) }, /* ConnectX-4 Flash Recovery             */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x020b) }, /* ConnectX-4Lx Flash Recovery           */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x020d) }, /* ConnectX-5 Flash Recovery             */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x020f) }, /* ConnectX-6 Flash Recovery             */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0210) }, /* ConnectX-6 Secure Flash Recovery      */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0211) }, /* BlueField Flash Recovery              */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0212) }, /* ConnectX-6 Dx Flash Recovery          */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0213) }, /* ConnectX-6 Dx Secure Flash Recovery   */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0214) }, /* BlueField-2 SoC Flash Recovery        */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0215) }, /* BlueField-2 Secure Flash Recovery     */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0216) }, /* ConnectX-6LX Flash Recovery           */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0217) }, /* ConnectX-6 Lx Secure Flash Recovery   */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0218) }, /* ConnectX-7 Flash Recovery             */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0219) }, /* ConnectX-7 Secure Flash Recovery      */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x021a) }, /* BlueField-3 Lx SoC Flash Recovery     */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x021b) }, /* BlueField-3 Lx Secure Flash Recovery  */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x021c) }, /* BlueField-3 SoC Flash Recovery        */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x021d) }, /* BlueField-3 Secure Flash Recovery     */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x021e) }, /* ConnectX-8 Flash Recovery             */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x021e) }, /* ConnectX-8 Secure Flash Recovery      */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x0220) }, /* BlueField-4 SoC Flash Recovery        */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 0x021e) }, /* BlueField-4 Secure Flash Recovery     */
         { 0, }
 };
 


### PR DESCRIPTION
Description:
PCI dev IDs for BF2-BF4
Livefish PCI dev IDs for all secure flash recovery
Livefish PCI dev IDs BF2-BF4 and CX8

Known gaps: CX8 PCI dev ID is not defined yet