### PR TITLE
Disable device support

### DIFF
--- a/mst_backward_compatibility/mst_pci/mst_pci_bc.h
+++ b/mst_backward_compatibility/mst_pci/mst_pci_bc.h
@@ -6,7 +6,7 @@
 
 #define PCI_INIT _IOC(_IOC_NONE,PCI_MAGIC,0,sizeof(struct mst_pci_init_st))
 struct mst_pci_init_st {
-	int          domain;
+	unsigned int domain;
 	unsigned int bus;
 	unsigned int devfn;
 	int bar;

--- a/mst_backward_compatibility/mst_pciconf/mst_pciconf_bc.h
+++ b/mst_backward_compatibility/mst_pciconf/mst_pciconf_bc.h
@@ -28,7 +28,7 @@ struct mst_hdr {
 
 #define PCICONF_INIT _IOC(_IOC_NONE,PCICONF_MAGIC,0,sizeof(struct mst_pciconf_init_st))
 struct mst_pciconf_init_st {
-        int          domain;
+        unsigned int domain;
         unsigned int bus;
         unsigned int devfn;
   /* Byte offsets in configuration space */

--- a/nnt_driver/nnt_device.h
+++ b/nnt_driver/nnt_device.h
@@ -9,13 +9,15 @@
 int create_nnt_devices(dev_t device_number, int is_mft_package,
                        struct file_operations* fop, int is_pciconf);
 void destroy_nnt_devices(void);
+void destroy_nnt_devices_bc(void);
+int destroy_nnt_device_bc(struct nnt_device* nnt_device);
 int is_memory_device(struct pci_dev* pdev);
 int is_pciconf_device(struct pci_dev* pdev);
 int get_amount_of_nvidia_devices(void);
 int set_private_data(struct file* file);
 void set_private_data_open(struct file* file);
-int set_private_data_bc(struct file* file, unsigned int current_bus,
-                        unsigned int current_device, unsigned int current_function);
+int set_private_data_bc(struct file* file, unsigned int bus,
+                        unsigned int devfn, unsigned int domain);
 int get_nnt_device(struct file* file, struct nnt_device** nnt_device);
 int mutex_lock_nnt(struct file* file);
 void mutex_unlock_nnt(struct file* file);

--- a/nnt_driver/nnt_device_defs.h
+++ b/nnt_driver/nnt_device_defs.h
@@ -26,9 +26,6 @@
 #define MST_BC_BUFFER_SIZE          256
 #define MST_BC_MAX_MINOR            256
 
-static struct pci_device_id pci_conf_devices[];
-static struct pci_device_id livefish_pci_devices[];
-static struct pci_device_id bar_pci_devices[];
 
 struct nnt_dma_page {
     struct page** page_list;
@@ -88,6 +85,13 @@ struct nnt_device_memory {
 };
 
 
+struct nnt_device_dbdf {
+    unsigned int domain;
+    unsigned int bus;
+    unsigned int devfn;
+};
+
+
 struct nnt_device {
     struct nnt_device_pciconf pciconf_device;
     struct nnt_device_memory memory_device;
@@ -98,10 +102,12 @@ struct nnt_device {
     struct list_head entry;
     struct cdev mcdev;
     struct mutex lock;
+    struct nnt_device_dbdf dbdf;
     enum nnt_device_type device_type;
     int vpd_capability_address;
     int wo_address;
     int buffer_used_bc;
+    int device_enabled;
     char device_name[NNT_NAME_SIZE];
     char buffer_bc[MST_BC_BUFFER_SIZE];
     dev_t device_number;

--- a/nnt_driver/nnt_device_list.h
+++ b/nnt_driver/nnt_device_list.h
@@ -15,9 +15,11 @@ static struct pci_device_id pciconf_devices[] = {
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 4125) },  /* ConnectX-6DX   */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 4127) },  /* ConnectX-6LX   */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 4129) },  /* ConnectX-7     */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 4131) },  /* ConnectX-8     */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 41682) }, /* BlueField      */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 41686) }, /* BlueField 2    */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 41692) }, /* BlueField 3    */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 45692) }, /* BlueField 3 toolspf   */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 41694) }, /* BlueField 4    */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 52000) }, /* SwitchIB       */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 53000) }, /* SwitchIB 2     */
@@ -74,6 +76,16 @@ static struct pci_device_id livefish_pci_devices[] = {
 static struct pci_device_id bar_pci_devices[] = {
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 4099) }, /* ConnectX-3    */
         { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 4103) }, /* ConnectX-3Pro */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 52000) }, /* SwitchIB       */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 53000) }, /* SwitchIB 2     */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 54000) }, /* Quantum        */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 54002) }, /* Quantum 2      */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 54004) }, /* Quantum 3      */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 52100) }, /* Spectrum 1     */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 53100) }, /* Spectrum 2     */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 53104) }, /* Spectrum 3     */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 53120) }, /* Spectrum 4     */
+        { PCI_DEVICE(NNT_NVIDIA_PCI_VENDOR, 45692) }, /* BlueField 3 toolspf   */
         { 0, }
 };
 

--- a/nnt_driver/nnt_pci_conf_access.c
+++ b/nnt_driver/nnt_pci_conf_access.c
@@ -23,7 +23,7 @@ int get_semaphore_ticket(struct nnt_device* nnt_device, unsigned int* lock_value
                          unsigned int* counter)
 {
     unsigned int counter_offset = nnt_device->pciconf_device.vendor_specific_capability + PCI_COUNTER_OFFSET;
-    int error;
+    int error = 0;
 
     /* Read ticket. */
     error = pci_read_config_dword(nnt_device->pci_device, counter_offset,
@@ -89,7 +89,7 @@ ReturnOnFinished:
 
 int read_dword(struct nnt_read_dword_from_config_space* read_from_cspace, struct nnt_device* nnt_device)
 {
-    int error;
+    int error = 0;
 
     /* Take semaphore. */
     error = lock_vsec_semaphore(nnt_device);
@@ -109,8 +109,8 @@ ReturnOnFinished:
 
 int wait_on_flag(struct nnt_device* nnt_device, u8 expected_val)
 {
-	unsigned int flag;
-	int retries;
+	unsigned int flag = 0;
+	int retries = 0;
 	int error = -1;
     
     for (retries = 0; retries < IFC_MAX_RETRIES; retries++) {
@@ -134,7 +134,7 @@ ReturnOnFinished:
 int set_address_space(struct nnt_device* nnt_device, unsigned int address_space)
 {
     unsigned int control_offset = nnt_device->pciconf_device.vendor_specific_capability + PCI_CONTROL_OFFSET;
-	unsigned int value;
+	unsigned int value = 0;
 	int error = 0;
 
     /* Read value from control offset. */
@@ -167,7 +167,7 @@ ReturnOnFinished:
 
 int check_address_space_support(struct nnt_device* nnt_device)
 {
-    int error;
+    int error = 0;
 
     if ((!nnt_device->pciconf_device.vendor_specific_capability) || (!nnt_device->pci_device)) {
 		    return 0;
@@ -249,8 +249,8 @@ ReturnOnFinished:
 
 int read_pciconf(struct nnt_device* nnt_device, struct nnt_rw_operation* read_operation)
 {
-    int counter;
-    int error;
+    int counter = 0;
+    int error = 0;
 
     /* Lock semaphore. */
     error = lock_vsec_semaphore(nnt_device);
@@ -304,8 +304,8 @@ ReturnOnFinished:
 
 int write_pciconf(struct nnt_device* nnt_device, struct nnt_rw_operation* write_operation)
 {
-    int counter;
-    int error;
+    int counter = 0;
+    int error = 0;
 
     /* Lock semaphore. */
     error = lock_vsec_semaphore(nnt_device);
@@ -375,7 +375,7 @@ int get_space_support_status(struct nnt_device* nnt_device, u_int16_t address_sp
 
 int init_vsec_capability_mask(struct nnt_device* nnt_device)
 {
-    int error;
+    int error = 0;
     
     /* Lock semaphore. */
     error = lock_vsec_semaphore(nnt_device);

--- a/nnt_driver/nnt_pci_conf_access_no_vsec.c
+++ b/nnt_driver/nnt_pci_conf_access_no_vsec.c
@@ -6,7 +6,7 @@
 int read_no_vsec(struct nnt_device* nnt_device, unsigned int offset,
                  unsigned int* data)
 {
-    int error;
+    int error = 0;
     
     if (nnt_device->wo_address) {
         offset |= 0x1;
@@ -30,7 +30,7 @@ ReturnOnFinished:
 
 int read_pciconf_no_vsec(struct nnt_device* nnt_device, struct nnt_rw_operation* read_operation)
 {
-    int counter;
+    int counter = 0;
     int error = 0;
 
     for (counter = 0; counter < read_operation->size; counter += 4) {
@@ -49,7 +49,7 @@ ReturnOnFinished:
 int write_no_vsec(struct nnt_device* nnt_device, unsigned int offset,
                   unsigned int data)
 {
-    int error;
+    int error = 0;
 
     if (nnt_device->wo_address) {
             /* write the data to the data register. */
@@ -83,7 +83,7 @@ ReturnOnFinished:
 
 int write_pciconf_no_vsec(struct nnt_device* nnt_device, struct nnt_rw_operation* write_operation)
 {
-    int counter;
+    int counter = 0;
     int error = 0;
 
 	for (counter = 0; counter < write_operation->size; counter += 4) {
@@ -102,7 +102,7 @@ ReturnOnFinished:
 int is_wo_gw(struct nnt_device* nnt_device)
 {
 	unsigned int data = 0;
-    int error;
+    int error = 0;
 
     error = pci_write_config_dword(nnt_device->pci_device, nnt_device->pciconf_device.address_register,
                                    NNT_DEVICE_ID_OFFSET);


### PR DESCRIPTION
Description:
Need to support 'mst rm' - cause to the nnt device to be disable until 'mst add' of the same device of mst restart. This logical should be replaced once we break the backward compatability, this flow will be implemented from the driver.

Tested OS: Linux | apps-69
Tested devices: 6DX
Tested flows:
1. Replace the driver with the new one.
2. mst rm 05:00.0 && mst rm 05:00.1
3. mst add 05:00.1
4. mst status -v

Known gaps (with RM ticket):

Issue: 3187096

------------------------

Reset flow should be done only on function 0

Description:
Fixing the iteration on the all function instead of the functino 0.

Tested OS: apps-21-06, PPC64
Tested devices: CX6
Tested flows:
make && sudo cp mst_ppc_pci_reset.ko /etc/mft/mlxfwreset/3.10.0-1160.el7.ppc64le/mst_ppc_pci_reset.ko && sudo mst restart && sudo mst status -v && sudo mlxfwreset -d /dev/mst/mt4123_pciconf0 r -y && dmesg && sudo mst status -v

Known gaps (with RM ticket):

Issue: 3217897