### PR TITLE
Fixing ppc driver location in ubuntu

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -66,7 +66,7 @@ ifneq ($(WITH_DKMS),1)
 	cp mst_backward_compatibility/mst_pciconf/mst_pciconf.ko	debian/$(pdkms)/lib/modules/$(kernelver)/$(INSTALL_MOD_DIR)
 ifneq "$(findstring ppc64, $(cpu_arch))" ""
 	mkdir -p debian/$(pdkms)/$(MLXFWRESET_KO_PATH)/$(kernelver)
-	cp mst_backward_compatibility/mst_ppc/mst_ppc_pci_reset.ko debian/$(pdkms)/$(MLXFWRESET_KO_PATH)/$(kernelver)
+	cp ./mst_backward_compatibility/mst_ppc/mst_ppc_pci_reset.ko debian/$(pdkms)/$(MLXFWRESET_KO_PATH)/$(kernelver)
 endif
 ifeq ($(WITH_MOD_SIGN),1)
 	tools/sign-modules $(INSTALL_MOD_PATH)/lib/modules/ $(kernel_source_dir)

--- a/scripts/install_mst_ppc_pci_reset.sh
+++ b/scripts/install_mst_ppc_pci_reset.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-kernel_version="`modinfo -Fvermagic ./mst_ppc_pci_reset.ko | awk '{ print $1 }'`"
+kernel_version="`modinfo -Fvermagic ./mst_backward_compatibility/mst_ppc/mst_ppc_pci_reset.ko | awk '{ print $1 }'`"
 path_to_build="`pwd`"
 path_to_build="$path_to_build/../build"
 cd $path_to_build
 
 mkdir -p /etc/mft/mlxfwreset/$kernel_version
-/bin/cp -f ./nnt_driver/mst_ppc_pci_reset.ko /etc/mft/mlxfwreset/$kernel_version/
+/bin/cp -f ./mst_backward_compatibility/mst_ppc/mst_ppc_pci_reset.ko /etc/mft/mlxfwreset/$kernel_version/
 
 cd -
 


### PR DESCRIPTION
Description:
PPC reset driver was located in the root directory of the kernel directory. NNT driver has multiple directories.

Tested OS: apps-21-08
Tested devices: Any
Tested flows: mlxfwreset -d /dev/mst/mt4127_pciconf0 -y r