### PR TITLE
Fixing the mstflint driver wrapper

### DIFF
--- a/mst_backward_compatibility/mst_pci/mst_pci_bc.c
+++ b/mst_backward_compatibility/mst_pci/mst_pci_bc.c
@@ -379,7 +379,6 @@ static int __init mst_pci_init_module(void)
 {
     dev_t device_number = -1;
     int is_mft_package = 1;
-    int is_pciconf = 0;
     int error = 0;
     
     /* Allocate char driver region and assign major number */
@@ -392,7 +391,7 @@ static int __init mst_pci_init_module(void)
 
     /* Create device files for MFT. */
     error = create_nnt_devices(device_number, is_mft_package,
-                               &fop, is_pciconf);
+                               &fop, NNT_PCI_DEVICES_FLAG);
    
     return error;
 }

--- a/mst_backward_compatibility/mst_pciconf/mst_pciconf_bc.c
+++ b/mst_backward_compatibility/mst_pciconf/mst_pciconf_bc.c
@@ -579,7 +579,6 @@ static int __init mst_pciconf_init_module(void)
 {
     dev_t device_number = -1;
     int is_mft_package = 1;
-    int is_pciconf = 1;
     int error = 0;
     
     /* Allocate char driver region and assign major number */
@@ -592,7 +591,7 @@ static int __init mst_pciconf_init_module(void)
 
     /* Create device files for MFT. */
     error = create_nnt_devices(device_number, is_mft_package,
-                               &fop, is_pciconf);
+                               &fop, NNT_PCICONF_DEVICES_FLAG);
    
     return error;
 }

--- a/nnt_driver/nnt_device.h
+++ b/nnt_driver/nnt_device.h
@@ -7,7 +7,7 @@
 
 
 int create_nnt_devices(dev_t device_number, int is_mft_package,
-                       struct file_operations* fop, int is_pciconf);
+                       struct file_operations* fop, int nnt_device_flag);
 void destroy_nnt_devices(void);
 void destroy_nnt_devices_bc(void);
 int destroy_nnt_device_bc(struct nnt_device* nnt_device);

--- a/nnt_driver/nnt_device_defs.h
+++ b/nnt_driver/nnt_device_defs.h
@@ -18,10 +18,15 @@
 #define NNT_MEMORY_SIZE				1024 * 1024
 #define VSEC_CAPABILITY_ADDRESS     0x9
 
-#define NNTFLINT_PCICONF_DEVICE_NAME    "nntconf"
-#define NNTFLINT_MEMORY_DEVICE_NAME     "nntcr"
+#define MSTFLINT_PCICONF_DEVICE_NAME    "mstconf"
+#define MSTFLINT_MEMORY_DEVICE_NAME     "mstcr"
 #define MFT_PCICONF_DEVICE_NAME         "pciconf"    
 #define MFT_MEMORY_DEVICE_NAME          "pci_cr"
+
+
+#define NNT_PCICONF_DEVICES_FLAG    0x1
+#define NNT_PCI_DEVICES_FLAG        0X2
+#define NNT_ALL_DEVICES_FLAG        0x3
 
 #define MST_BC_BUFFER_SIZE          256
 #define MST_BC_MAX_MINOR            256


### PR DESCRIPTION
Description:
NNT driver will create the device file of the mstflint.

Tested OS: apps-69, Linux
Tested devices: ALL
Tested flows: Compilation passed + insmod mstflint_access.ko

Known gaps (with RM ticket): N/A

Issue: 3215410