### PR TITLE
NNT Driver | Destory devices from mstflint driver wrapper support

### DIFF
--- a/mst_backward_compatibility/mst_pci/mst_pci_bc.c
+++ b/mst_backward_compatibility/mst_pci/mst_pci_bc.c
@@ -378,7 +378,7 @@ struct file_operations fop = {
 static int __init mst_pci_init_module(void)
 {
     dev_t device_number = -1;
-    int is_mft_package = 1;
+    int is_alloc_chrdev_region = 0;
     int error = 0;
     
     /* Allocate char driver region and assign major number */
@@ -390,7 +390,7 @@ static int __init mst_pci_init_module(void)
 	}
 
     /* Create device files for MFT. */
-    error = create_nnt_devices(device_number, is_mft_package,
+    error = create_nnt_devices(device_number, is_alloc_chrdev_region,
                                &fop, NNT_PCI_DEVICES_FLAG);
    
     return error;
@@ -401,7 +401,9 @@ static int __init mst_pci_init_module(void)
 
 static void __exit mst_pci_cleanup_module(void)
 {
-    destroy_nnt_devices();
+    int is_alloc_chrdev_region = 0;
+
+    destroy_nnt_devices(is_alloc_chrdev_region);
     unregister_chrdev(major_number, name);
 }
 

--- a/mst_backward_compatibility/mst_pciconf/mst_pciconf_bc.c
+++ b/mst_backward_compatibility/mst_pciconf/mst_pciconf_bc.c
@@ -578,7 +578,7 @@ struct file_operations fop = {
 static int __init mst_pciconf_init_module(void)
 {
     dev_t device_number = -1;
-    int is_mft_package = 1;
+    int is_alloc_chrdev_region = 0;
     int error = 0;
     
     /* Allocate char driver region and assign major number */
@@ -590,7 +590,7 @@ static int __init mst_pciconf_init_module(void)
 	}
 
     /* Create device files for MFT. */
-    error = create_nnt_devices(device_number, is_mft_package,
+    error = create_nnt_devices(device_number, is_alloc_chrdev_region,
                                &fop, NNT_PCICONF_DEVICES_FLAG);
    
     return error;
@@ -601,7 +601,9 @@ static int __init mst_pciconf_init_module(void)
 
 static void __exit mst_pciconf_cleanup_module(void)
 {
-    destroy_nnt_devices();
+    int is_alloc_chrdev_region = 0;
+
+    destroy_nnt_devices(is_alloc_chrdev_region);
     unregister_chrdev(major_number, name);
 }
 

--- a/nnt_driver/nnt_defs.h
+++ b/nnt_driver/nnt_defs.h
@@ -40,7 +40,7 @@ extern struct driver_info nnt_driver_info;
 
 
 struct driver_info {
-    int driver_major_number;
+    dev_t device_number;
     int contiguous_device_numbers;
     struct class* class_driver;
 };

--- a/nnt_driver/nnt_device.h
+++ b/nnt_driver/nnt_device.h
@@ -6,9 +6,9 @@
 #include "nnt_device_defs.h"
 
 
-int create_nnt_devices(dev_t device_number, int is_mft_package,
+int create_nnt_devices(dev_t device_number, int is_alloc_chrdev_region,
                        struct file_operations* fop, int nnt_device_flag);
-void destroy_nnt_devices(void);
+void destroy_nnt_devices(int is_alloc_chrdev_region);
 void destroy_nnt_devices_bc(void);
 int destroy_nnt_device_bc(struct nnt_device* nnt_device);
 int is_memory_device(struct pci_dev* pdev);


### PR DESCRIPTION
Description:

Tested OS: Apps-65
Tested devices: All
Tested flows:
cd /swgwork/itayavr/temp/NNT-Linux-driver/mstflint && make && sudo insmod mstflint_access.ko && sudo rmmod mstflint_access && sudo mst status

Known gaps (with RM ticket):

Issue: 3215410