### PR TITLE
NNT Driver | Acquire the mutex exclusively for the current task

### DIFF
--- a/mst_backward_compatibility/mst_pci/mst_pci_bc.c
+++ b/mst_backward_compatibility/mst_pci/mst_pci_bc.c
@@ -65,6 +65,8 @@ static ssize_t mst_pci_bc_read(struct file* file, char* buf,
     } else {
         buffer = nnt_device->buffer_bc;
         buffer_used = &nnt_device->buffer_used_bc;
+        error = mutex_lock_nnt(file);
+        CHECK_ERROR(error);
     }
 
 	if (*f_pos >= *buffer_used) {
@@ -88,6 +90,7 @@ MutexUnlock:
             mutex_unlock_nnt(file);
     }
 
+ReturnOnFinished:
 	return count;
 }
 
@@ -113,6 +116,8 @@ static ssize_t mst_pci_bc_write(struct file* file, const char* buf,
     } else {
             buffer = nnt_device->buffer_bc;
             buffer_used = &nnt_device->buffer_used_bc;
+            error = mutex_lock_nnt(file);
+            CHECK_ERROR(error);
     }
 
 	if (*f_pos >= MST_BC_BUFFER_SIZE) {
@@ -136,7 +141,11 @@ static ssize_t mst_pci_bc_write(struct file* file, const char* buf,
     }
 
 MutexUnlock:
-    mutex_unlock_nnt(file);
+    if (nnt_device) {
+            mutex_unlock_nnt(file);
+    }
+
+ReturnOnFinished:
 	return count;
 }
 

--- a/nnt_driver/nnt_device.c
+++ b/nnt_driver/nnt_device.c
@@ -363,8 +363,7 @@ int create_nnt_devices(dev_t device_number, int is_alloc_chrdev_region,
     while ((pci_device = pci_get_device(NNT_NVIDIA_PCI_VENDOR, PCI_ANY_ID,
                                         pci_device)) != NULL) {
 
-            if (nnt_device_flag &
-                    (NNT_PCICONF_DEVICES_FLAG || nnt_device_flag & NNT_ALL_DEVICES_FLAG)) {
+            if ((nnt_device_flag & NNT_PCICONF_DEVICES_FLAG) || (nnt_device_flag & NNT_ALL_DEVICES_FLAG)) {
                     /* Create pciconf device. */
                     if (is_pciconf_device(pci_device)) {
                             if ((error_code =
@@ -376,8 +375,7 @@ int create_nnt_devices(dev_t device_number, int is_alloc_chrdev_region,
                     }
             }
 
-            if (nnt_device_flag &
-                    (NNT_PCI_DEVICES_FLAG || nnt_device_flag & NNT_ALL_DEVICES_FLAG)) {
+            if ((nnt_device_flag & NNT_PCI_DEVICES_FLAG) || (nnt_device_flag & NNT_ALL_DEVICES_FLAG)) {
                     /* Create pci memory device. */
                     if (is_memory_device(pci_device)) {
                             if ((error_code =


### PR DESCRIPTION
Description:
Missing a lock mechanism in write function.

Tested OS: apps-69, r-anaconda-05
Tested devices: Spectrum2
Tested flows: Compilation on the server, replacing the mst_pci.ko and reboot.

Known gaps (with RM ticket):

Issue: 3232564