### PR TITLE
NNT Driver | Remove duplicate "device found prints"

### DIFF
--- a/mst_backward_compatibility/mst_pci/mst_pci_bc.c
+++ b/mst_backward_compatibility/mst_pci/mst_pci_bc.c
@@ -400,7 +400,7 @@ static int __init mst_pci_init_module(void)
 
     /* Create device files for MFT. */
     error = create_nnt_devices(device_number, is_alloc_chrdev_region,
-                               &fop, NNT_PCI_DEVICES_FLAG);
+                               &fop, NNT_PCI_DEVICES);
    
     return error;
 }

--- a/mst_backward_compatibility/mst_pciconf/mst_pciconf_bc.c
+++ b/mst_backward_compatibility/mst_pciconf/mst_pciconf_bc.c
@@ -591,7 +591,7 @@ static int __init mst_pciconf_init_module(void)
 
     /* Create device files for MFT. */
     error = create_nnt_devices(device_number, is_alloc_chrdev_region,
-                               &fop, NNT_PCICONF_DEVICES_FLAG);
+                               &fop, NNT_PCICONF_DEVICES);
    
     return error;
 }

--- a/mstflint/mst_main.c
+++ b/mstflint/mst_main.c
@@ -602,7 +602,7 @@ static int __init mstflint_init_module(void)
     /* Create device files for MSTflint. */
     if((error =
             create_nnt_devices(nnt_driver_info.device_number, is_alloc_chrdev_region,
-                               &fop, NNT_ALL_DEVICES_FLAG)) == 0) {
+                               &fop, NNT_ALL_DEVICES)) == 0) {
             goto ReturnOnFinished;
     }
 

--- a/nnt_driver/nnt_device.c
+++ b/nnt_driver/nnt_device.c
@@ -354,7 +354,7 @@ ReturnOnFinished:
 
 
 int create_nnt_devices(dev_t device_number, int is_alloc_chrdev_region,
-                       struct file_operations* fop, int nnt_device_flag)
+                       struct file_operations* fop, enum nnt_device_type_flag nnt_device_flag)
 {
     struct pci_dev* pci_device = NULL;
     int error_code = 0;
@@ -363,7 +363,7 @@ int create_nnt_devices(dev_t device_number, int is_alloc_chrdev_region,
     while ((pci_device = pci_get_device(NNT_NVIDIA_PCI_VENDOR, PCI_ANY_ID,
                                         pci_device)) != NULL) {
 
-            if ((nnt_device_flag & NNT_PCICONF_DEVICES_FLAG) || (nnt_device_flag & NNT_ALL_DEVICES_FLAG)) {
+            if ((nnt_device_flag == NNT_PCICONF_DEVICES) || (nnt_device_flag == NNT_ALL_DEVICES)) {
                     /* Create pciconf device. */
                     if (is_pciconf_device(pci_device)) {
                             if ((error_code =
@@ -375,7 +375,7 @@ int create_nnt_devices(dev_t device_number, int is_alloc_chrdev_region,
                     }
             }
 
-            if ((nnt_device_flag & NNT_PCI_DEVICES_FLAG) || (nnt_device_flag & NNT_ALL_DEVICES_FLAG)) {
+            if ((nnt_device_flag == NNT_PCI_DEVICES) || (nnt_device_flag == NNT_ALL_DEVICES)) {
                     /* Create pci memory device. */
                     if (is_memory_device(pci_device)) {
                             if ((error_code =

--- a/nnt_driver/nnt_device.h
+++ b/nnt_driver/nnt_device.h
@@ -7,7 +7,7 @@
 
 
 int create_nnt_devices(dev_t device_number, int is_alloc_chrdev_region,
-                       struct file_operations* fop, int nnt_device_flag);
+                       struct file_operations* fop, enum nnt_device_type_flag nnt_device_flag);
 void destroy_nnt_devices(int is_alloc_chrdev_region);
 void destroy_nnt_devices_bc(void);
 int destroy_nnt_device_bc(struct nnt_device* nnt_device);

--- a/nnt_driver/nnt_device_defs.h
+++ b/nnt_driver/nnt_device_defs.h
@@ -23,14 +23,15 @@
 #define MFT_PCICONF_DEVICE_NAME         "pciconf"    
 #define MFT_MEMORY_DEVICE_NAME          "pci_cr"
 
-
-#define NNT_PCICONF_DEVICES_FLAG    0x1
-#define NNT_PCI_DEVICES_FLAG        0X2
-#define NNT_ALL_DEVICES_FLAG        0x3
-
 #define MST_BC_BUFFER_SIZE          256
 #define MST_BC_MAX_MINOR            256
 
+
+enum nnt_device_type_flag {
+    NNT_PCICONF_DEVICES = 0x01,
+    NNT_PCI_DEVICES,
+    NNT_ALL_DEVICES
+};
 
 struct nnt_dma_page {
     struct page** page_list;


### PR DESCRIPTION
Description:
mst_pci and mst_pciconf are drivers that looking for a Mellanox device. each of them should discover the corresponding device.

Tested OS: apps-69, r-anaconda-20
Tested devices: Spectrum2
Tested flows: Compilation on the server, replacing the mst_pci.ko and reboot.

Known gaps (with RM ticket):

Issue: 3232564